### PR TITLE
fix: make the anchor tags actually clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For substantial changes, we ask that a "request for comment" (RFC) document is p
 
 <div class="people-grid">
 {% for person in site.github.organization_members %}
-  <a style="display:block;text-align:center;" src="{{ person.html_url }}">
+  <a style="display:block;text-align:center;" href="{{ person.html_url }}">
   <img style="width:48px;max-height:48px;" src="{{ person.avatar_url }}"/>
   <div>{{ person.login }}</div>
   </a>


### PR DESCRIPTION
I was visiting this page while reading some dev-tools docs and noticed the links to folks' Github profiles are not actually clickable. If this is how you want it, now they are.
@sole for review?