### PR TITLE
fix: Fix broken link for the codetribute bug listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Help us maintain an inclusive environment by following our [code of conduct](COD
 Help build the last independent browser. Write code, fix bugs, make add-ons, and more.
 
 - [Contributor docs](https://firefox-source-docs.mozilla.org/devtools)
-- [Good first bugs](https://codetribute.mozilla.org/projects/devtools)
+- [Good first bugs](https://codetribute.mozilla.org/projects/firefox-devtools)
 
 ## Speak Up
 - [File bugs](https://bugzilla.mozilla.org/enter_bug.cgi?product=DevTools&component=General)

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                 >
               </li>
               <li>
-                <a href="https://codetribute.mozilla.org/projects/devtools"
+                <a href="https://codetribute.mozilla.org/projects/firefox-devtools"
                   >Good first bugs</a
                 >
               </li>


### PR DESCRIPTION
This patch fixes the broken url for codetribute listing of good first bugs in the README.md and index.html.